### PR TITLE
Upgrade recast dependency to ~0.8.0 [Fixes #1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "browser": "index.js",
   "dependencies": {
-    "recast": "~0.5.7"
+    "recast": "~0.8.0"
   },
   "devDependencies": {
-    "faucet": "0.0.0"
+    "faucet": "0.0.0",
+    "tape": "^4.0.0"
   },
   "scripts": {
     "test": "faucet test.js"


### PR DESCRIPTION
Fixes #1

~0.8.x was the last version before it dropped support for some syntax that `replace-method` uses.
